### PR TITLE
Make LengthConverter and LengthFormatter implementations public

### DIFF
--- a/library/android/src/main/java/io/mehow/ruler/AutoFitLengthConverter.kt
+++ b/library/android/src/main/java/io/mehow/ruler/AutoFitLengthConverter.kt
@@ -5,7 +5,7 @@ import io.mehow.ruler.ImperialLengthUnit.Yard
 import io.mehow.ruler.SiLengthUnit.Kilometer
 import io.mehow.ruler.SiLengthUnit.Meter
 
-internal object AutoFitLengthConverter : LengthConverter {
+object AutoFitLengthConverter : LengthConverter {
   @Suppress("UNCHECKED_CAST")
   override fun Length<*>.convert(context: Context): Length<*>? {
     val length = if (context.preferredLocale.isImperial) withUnit(Yard) else withUnit(Meter)

--- a/library/android/src/main/java/io/mehow/ruler/AutoLengthFormatter.kt
+++ b/library/android/src/main/java/io/mehow/ruler/AutoLengthFormatter.kt
@@ -13,7 +13,7 @@ import io.mehow.ruler.SiLengthUnit.Micrometer
 import io.mehow.ruler.SiLengthUnit.Millimeter
 import io.mehow.ruler.SiLengthUnit.Nanometer
 
-internal object AutoLengthFormatter : LengthFormatter {
+object AutoLengthFormatter : LengthFormatter {
   @Volatile internal var useImperialFormatter = true
 
   override fun Length<*>.format(context: Context, separator: String): String? {

--- a/library/android/src/main/java/io/mehow/ruler/FlooredLengthFormatter.kt
+++ b/library/android/src/main/java/io/mehow/ruler/FlooredLengthFormatter.kt
@@ -13,7 +13,7 @@ import io.mehow.ruler.SiLengthUnit.Micrometer
 import io.mehow.ruler.SiLengthUnit.Millimeter
 import io.mehow.ruler.SiLengthUnit.Nanometer
 
-internal object FlooredLengthFormatter : LengthFormatter {
+object FlooredLengthFormatter : LengthFormatter {
   override fun Length<*>.format(context: Context, separator: String): String? {
     return when (unit) {
       is SiLengthUnit -> {


### PR DESCRIPTION
Right now, there is no possibility to reuse the default formatters and converter, but it might be convenient to, e.g. use flooredFormatter with a custom converter. I decided to make formatters and converter from `Ruler` object public, but a similar effect can be achieved by making particular implementations public, not internal.

Edit: I reverted the changes and make implementations public